### PR TITLE
:package: Replace anyhow with color_eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,12 +127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +740,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1118,16 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
 
 [[package]]
 name = "fastrand"
@@ -1664,6 +1695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2114,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking"
@@ -3045,6 +3088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,13 +3374,13 @@ dependencies = [
 name = "surrealdb-migrations"
 version = "1.0.0-preview.1"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "assert_fs",
  "chrono",
  "chrono-human-duration",
  "clap 4.4.3",
  "cli-table",
+ "color-eyre",
  "convert_case",
  "diffy",
  "dir-diff",
@@ -3653,6 +3705,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3819,6 +3893,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.71"
 chrono = "0.4.26"
 chrono-human-duration = "0.1.1"
 clap = { version = "4.3.0", features = ["derive"] }
@@ -32,6 +31,7 @@ serde = { version = "1.0.163", features = ["derive"] }
 tokio = { version = "1.28.1", features = ["macros"] }
 sqlparser = "0.38.0"
 surrealdb = { version = "1.0.0", features = ["protocol-http"] }
+color-eyre = "0.6.2"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -9,7 +9,7 @@ use ::surrealdb::{
     },
     Connection, Surreal,
 };
-use anyhow::{anyhow, Context, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use include_dir::Dir;
 
 use crate::{
@@ -310,7 +310,7 @@ fn expect_migration_definitions_to_be_up_to_date(
         Ok(())
     } else {
         const ERROR_MESSAGE: &str = "The migration definitions are not up to date. Please run `surrealdb-migrations apply` on your local environment and publish definitions files.";
-        Err(anyhow!(ERROR_MESSAGE))
+        Err(eyre!(ERROR_MESSAGE))
     }
 }
 

--- a/src/branch/common.rs
+++ b/src/branch/common.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use anyhow::Result;
+use color_eyre::eyre::{Result};
 use surrealdb::{engine::any::Any, Surreal};
 
 use crate::{input::SurrealdbConfiguration, models::Branch, surrealdb::create_surrealdb_client};

--- a/src/branch/diff.rs
+++ b/src/branch/diff.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -158,7 +158,7 @@ pub async fn main(args: BranchDiffArgs<'_>) -> Result<()> {
             }
         }
         None => {
-            return Err(anyhow!("Branch {} does not exist", name));
+            return Err(eyre!("Branch {} does not exist", name));
         }
     }
 

--- a/src/branch/list.rs
+++ b/src/branch/list.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::eyre::{Result};
 use chrono::{DateTime, Utc};
 use chrono_human_duration::ChronoHumanDuration;
 use cli_table::{format::Border, Cell, ColorChoice, Style, Table};

--- a/src/branch/merge/mod.rs
+++ b/src/branch/merge/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::eyre::{eyre, Result};
 
 use crate::{
     branch::constants::BRANCH_TABLE, cli::BranchMergeMode, input::SurrealdbConfiguration,
@@ -49,6 +49,6 @@ pub async fn main(args: MergeBranchArgs<'_>) -> Result<()> {
                 overwrite::main(args).await
             }
         },
-        None => Err(anyhow!("Branch {} does not exist", name)),
+        None => Err(eyre!("Branch {} does not exist", name)),
     }
 }

--- a/src/branch/merge/overwrite.rs
+++ b/src/branch/merge/overwrite.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::eyre::{Result};
 use std::path::PathBuf;
 
 use crate::{

--- a/src/branch/new.rs
+++ b/src/branch/new.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Context, Result};
 use chrono::Utc;
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use include_dir::{include_dir, Dir};
 use names::{Generator, Name};
 use std::path::PathBuf;
@@ -130,7 +130,7 @@ fn fails_if_branch_already_exists(
 ) -> Result<()> {
     if let Some(name) = branch_name {
         if existing_branch_names.contains(&name) {
-            return Err(anyhow!("Branch name already exists"));
+            return Err(eyre!("Branch name already exists"));
         }
     }
 
@@ -221,7 +221,7 @@ async fn save_branch_in_database(
         .await?;
 
     if record.is_none() {
-        return Err(anyhow!("Cannot insert branch name into branch table"));
+        return Err(eyre!("Cannot insert branch name into branch table"));
     }
 
     Ok(())

--- a/src/branch/remove.rs
+++ b/src/branch/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::eyre::{eyre, Result};
 
 use crate::{
     branch::{
@@ -32,7 +32,7 @@ pub async fn main(args: RemoveBranchArgs<'_>) -> Result<()> {
     let existing_branch_names = retrieve_existing_branch_names(&branching_feature_client).await?;
 
     if !existing_branch_names.contains(&name) {
-        return Err(anyhow!("Branch {} does not exist", name));
+        return Err(eyre!("Branch {} does not exist", name));
     }
 
     // Prevent branch to be removed if used by another branch
@@ -45,7 +45,7 @@ pub async fn main(args: RemoveBranchArgs<'_>) -> Result<()> {
     let number_of_dependent_branches = number_of_dependent_branches.unwrap_or(0);
 
     if number_of_dependent_branches > 0 {
-        return Err(anyhow!("Branch {} is used by another branch", name));
+        return Err(eyre!("Branch {} is used by another branch", name));
     }
 
     // Remove databases created for this branch

--- a/src/branch/status.rs
+++ b/src/branch/status.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use chrono_human_duration::ChronoHumanDuration;
+use color_eyre::eyre::{eyre, Result};
 
 use crate::{
     branch::{
@@ -49,6 +49,6 @@ pub async fn main(args: BranchStatusArgs<'_>) -> Result<()> {
 
             Ok(())
         }
-        None => Err(anyhow!("Branch {} does not exist", name)),
+        None => Err(eyre!("Branch {} does not exist", name)),
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::eyre::{eyre, Result};
 use std::path::PathBuf;
 
 use crate::{
@@ -69,7 +69,7 @@ pub fn main(args: CreateArgs) -> Result<()> {
         }
 
         if file_path.exists() {
-            return Err(anyhow!("File {} already exists", filename));
+            return Err(eyre!("File {} already exists", filename));
         }
     }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
 use fs_extra::dir::{DirEntryAttr, DirEntryValue};
 use include_dir::Dir;
 use std::{
@@ -602,7 +602,7 @@ pub fn get_current_definition(
 
     let initial_definition_str = match initial_definition_file {
         Some(initial_definition_file) => initial_definition_file.get_content().unwrap_or_default(),
-        None => return Err(anyhow!("Initial definition file not found")),
+        None => return Err(eyre!("Initial definition file not found")),
     };
 
     let initial_definition =
@@ -672,7 +672,11 @@ fn extract_initial_definition_content(
             };
 
             let initial_definition_filepath = definitions_path.join(INITIAL_DEFINITION_FILENAME);
-            let content = fs_extra::file::read_to_string(initial_definition_filepath)?;
+            let content =
+                fs_extra::file::read_to_string(&initial_definition_filepath).wrap_err(format!(
+                    "initial_definition_filepath not found at: {:?}",
+                    initial_definition_filepath,
+                ))?;
 
             Ok(content)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! # Get started
 //!
 //! ```rust,no_run
-//! # use anyhow::Result;
+//! # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
 //! use surrealdb_migrations::MigrationRunner;
 //! use surrealdb::engine::any::connect;
 //! use surrealdb::opt::auth::Root;
@@ -64,8 +64,8 @@ mod surrealdb;
 mod validate_version_order;
 
 use ::surrealdb::{Connection, Surreal};
-use anyhow::Result;
 use apply::ApplyArgs;
+use color_eyre::eyre::{Result};
 use include_dir::Dir;
 use models::ScriptMigration;
 use validate_version_order::ValidateVersionOrderArgs;
@@ -107,7 +107,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use include_dir::{include_dir, Dir};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
@@ -152,7 +152,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use include_dir::{include_dir, Dir};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
@@ -196,7 +196,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
     /// use surrealdb::opt::auth::Root;
@@ -236,7 +236,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
     /// use surrealdb::opt::auth::Root;
@@ -284,7 +284,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
     /// use surrealdb::opt::auth::Root;
@@ -332,7 +332,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
     /// use surrealdb::opt::auth::Root;
@@ -376,7 +376,7 @@ impl<'a, C: Connection> MigrationRunner<'a, C> {
     /// ## Examples
     ///
     /// ```rust,no_run
-    /// # use anyhow::Result;
+    /// # use color_eyre::eyre::{eyre, ContextCompat, Result, WrapErr};
     /// use surrealdb_migrations::MigrationRunner;
     /// use surrealdb::engine::any::connect;
     /// use surrealdb::opt::auth::Root;

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::eyre::{Result};
 use chrono::{DateTime, Utc};
 use chrono_human_duration::ChronoHumanDuration;
 use cli_table::{format::Border, Cell, ColorChoice, Style, Table};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use crate::surrealdb::create_surrealdb_client;
 
-use anyhow::{anyhow, Result};
 use apply::ApplyArgs;
 use branch::{
     diff::BranchDiffArgs, list::ListBranchArgs, merge::MergeBranchArgs, new::NewBranchArgs,
@@ -8,6 +7,8 @@ use branch::{
 };
 use clap::Parser;
 use cli::{Action, Args, BranchAction, CreateAction, ScaffoldAction};
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::Result;
 use create::{CreateArgs, CreateEventArgs, CreateMigrationArgs, CreateOperation, CreateSchemaArgs};
 use input::SurrealdbConfiguration;
 use list::ListArgs;
@@ -31,6 +32,7 @@ mod validate_version_order;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    color_eyre::install()?;
     let args = Args::parse();
 
     let config_file = args.config_file.as_deref();
@@ -128,7 +130,7 @@ async fn main() -> Result<()> {
                         };
                         create::main(args)
                     }
-                    None => Err(anyhow!("No action specified for `create` command")),
+                    None => Err(eyre!("No action specified for `create` command")),
                 },
             }
         }
@@ -150,7 +152,7 @@ async fn main() -> Result<()> {
 
             let operation = match (up, down) {
                 (Some(_), Some(_)) => {
-                    return Err(anyhow!(
+                    return Err(eyre!(
                         "You can't specify both `up` and `down` parameters at the same time"
                     ))
                 }
@@ -336,7 +338,7 @@ async fn main() -> Result<()> {
                         };
                         branch::diff::main(args).await
                     }
-                    None => Err(anyhow!("No action specified for `branch` command")),
+                    None => Err(eyre!("No action specified for `branch` command")),
                 },
             }
         }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use std::path::Path;
 
 use crate::{
@@ -12,7 +12,7 @@ pub fn main(config_file: Option<&str>) -> Result<()> {
     let forward_migrations_files = io::extract_forward_migrations_files(config_file, None);
 
     if forward_migrations_files.is_empty() {
-        return Err(anyhow!("No migration files left"));
+        return Err(eyre!("No migration files left"));
     }
 
     let last_migration = forward_migrations_files

--- a/src/scaffold/common.rs
+++ b/src/scaffold/common.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Local};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use include_dir::{include_dir, Dir};
 use std::{
     io::Write,
@@ -43,7 +43,7 @@ pub fn apply_after_scaffold(folder_path: Option<String>) -> Result<()> {
 
 fn fails_if_folder_already_exists(dir_path: &Path, dir_name: &str) -> Result<()> {
     match dir_path.exists() {
-        true => Err(anyhow!("'{}' folder already exists.", dir_name)),
+        true => Err(eyre!("'{}' folder already exists.", dir_name)),
         false => Ok(()),
     }
 }

--- a/src/scaffold/schema.rs
+++ b/src/scaffold/schema.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::eyre::{eyre, Result};
 use convert_case::{Case, Casing};
 use std::{collections::HashMap, ops::Deref};
 
@@ -95,11 +95,11 @@ fn scaffold_from_schema(
     let schema = convert_ast_to_surrealdb_schema(ast, preserve_casing)?;
 
     if schema.tables.is_empty() {
-        return Err(anyhow!("No table found in schema file."));
+        return Err(eyre!("No table found in schema file."));
     }
 
     if schema.tables.contains_key(SCRIPT_MIGRATION_TABLE_NAME) {
-        return Err(anyhow!(
+        return Err(eyre!(
             "The table '{}' is reserved for internal use.",
             SCRIPT_MIGRATION_TABLE_NAME
         ));
@@ -367,9 +367,7 @@ fn convert_ast_to_surrealdb_schema(
                         unique,
                     });
 
-                let line_definitions = tables
-                    .entry(table_name)
-                    .or_default();
+                let line_definitions = tables.entry(table_name).or_default();
                 line_definitions.push(line_definition);
             }
             _ => {}

--- a/src/scaffold/template.rs
+++ b/src/scaffold/template.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::eyre::{Result};
 
 use crate::{cli::ScaffoldTemplate, config};
 

--- a/src/surrealdb.rs
+++ b/src/surrealdb.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use surrealdb::{
     engine::any::{connect, Any},
     opt::auth::{Jwt, Root},
@@ -117,7 +117,7 @@ pub async fn apply_in_transaction<C: Connection>(
             if is_rollback_success {
                 Ok(())
             } else {
-                Err(anyhow!(first_error))
+                Err(eyre!(first_error))
             }
         }
         TransactionAction::Commit => {

--- a/src/validate_version_order.rs
+++ b/src/validate_version_order.rs
@@ -1,5 +1,5 @@
 use ::surrealdb::{Connection, Surreal};
-use anyhow::{anyhow, Result};
+use color_eyre::eyre::{eyre, Result};
 use include_dir::Dir;
 
 use crate::{
@@ -54,7 +54,7 @@ pub async fn main<C: Connection>(args: ValidateVersionOrderArgs<'_, C>) -> Resul
             .map(|migration_file| migration_file.name.to_string())
             .collect::<Vec<_>>();
 
-        Err(anyhow!(
+        Err(eyre!(
             "The following migrations have not been applied: {}",
             migration_names.join(", ")
         ))

--- a/tests/cli/apply/common.rs
+++ b/tests/cli/apply/common.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 use serial_test::serial;
 
 use crate::helpers::*;

--- a/tests/cli/apply/down.rs
+++ b/tests/cli/apply/down.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use color_eyre::eyre::{ensure, Result};
 use assert_fs::TempDir;
 
 use crate::helpers::*;

--- a/tests/cli/apply/e2e.rs
+++ b/tests/cli/apply/e2e.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::eyre::{ensure, Result};
 
 use crate::helpers::*;
 
@@ -43,9 +43,15 @@ Migration files successfully executed!\n",
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 1);
+    ensure!(
+        definitions_files.count() == 1,
+        "Wrong number of definitions files"
+    );
 
-    ensure!(definitions_dir.join("_initial.json").exists());
+    ensure!(
+        definitions_dir.join("_initial.json").exists(),
+        "Initial definition file should exist"
+    );
 
     Ok(())
 }
@@ -75,18 +81,30 @@ async fn apply_3_consecutives_schema_and_data_changes() -> Result<()> {
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 1);
+    ensure!(
+        definitions_files.count() == 1,
+        "Wrong number of definitions files"
+    );
 
     let initial_definition_file_path = definitions_dir.join("_initial.json");
 
-    ensure!(initial_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Initial definition file should exist"
+    );
 
     let initial_migration_definition_str = std::fs::read_to_string(&initial_definition_file_path)?;
     let initial_migration_definition =
         serde_json::from_str::<MigrationDefinition>(&initial_migration_definition_str)?;
 
-    ensure!(initial_migration_definition.schemas == Some(INITIAL_DEFINITION_SCHEMAS.to_string()));
-    ensure!(initial_migration_definition.events == Some(INITIAL_DEFINITION_EVENTS.to_string()));
+    ensure!(
+        initial_migration_definition.schemas == Some(INITIAL_DEFINITION_SCHEMAS.to_string()),
+        "Initial migration: wrong schemas"
+    );
+    ensure!(
+        initial_migration_definition.events == Some(INITIAL_DEFINITION_EVENTS.to_string()),
+        "Initial migration: wrong events"
+    );
 
     // Check data
     let ns_db = Some(("test", db_name.as_str()));
@@ -125,13 +143,22 @@ async fn apply_3_consecutives_schema_and_data_changes() -> Result<()> {
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 2);
+    ensure!(
+        definitions_files.count() == 2,
+        "Wrong number of definitions files"
+    );
 
     let second_migration_definition_file_path =
         definitions_dir.join(format!("{second_migration_name}.json"));
 
-    ensure!(initial_definition_file_path.exists());
-    ensure!(second_migration_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Initial definition file should exist"
+    );
+    ensure!(
+        second_migration_definition_file_path.exists(),
+        "Second definition file should exist"
+    );
 
     let new_initial_migration_definition_str =
         std::fs::read_to_string(&initial_definition_file_path)?;
@@ -145,8 +172,14 @@ async fn apply_3_consecutives_schema_and_data_changes() -> Result<()> {
     let second_migration_definition =
         serde_json::from_str::<MigrationDefinition>(&second_migration_definition_str)?;
 
-    ensure!(second_migration_definition.schemas == Some(SECOND_MIGRATION_SCHEMAS.to_string()));
-    ensure!(second_migration_definition.events.is_none());
+    ensure!(
+        second_migration_definition.schemas == Some(SECOND_MIGRATION_SCHEMAS.to_string()),
+        "Second migration: wrong schemas"
+    );
+    ensure!(
+        second_migration_definition.events.is_none(),
+        "Second migration: wrong events"
+    );
 
     // Check data
     let is_table_empty = is_surreal_table_empty(ns_db, "post").await?;
@@ -183,14 +216,26 @@ async fn apply_3_consecutives_schema_and_data_changes() -> Result<()> {
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 3);
+    ensure!(
+        definitions_files.count() == 3,
+        "Wrong number of definitions files"
+    );
 
     let third_migration_definition_file_path =
         definitions_dir.join(format!("{third_migration_name}.json"));
 
-    ensure!(initial_definition_file_path.exists());
-    ensure!(second_migration_definition_file_path.exists());
-    ensure!(third_migration_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Initial definition file should exist"
+    );
+    ensure!(
+        second_migration_definition_file_path.exists(),
+        "Second definition file should exist"
+    );
+    ensure!(
+        third_migration_definition_file_path.exists(),
+        "Third definition file should exist"
+    );
 
     let new_initial_migration_definition_str =
         std::fs::read_to_string(initial_definition_file_path)?;
@@ -204,8 +249,14 @@ async fn apply_3_consecutives_schema_and_data_changes() -> Result<()> {
     let third_migration_definition =
         serde_json::from_str::<MigrationDefinition>(&third_migration_definition_str)?;
 
-    ensure!(third_migration_definition.schemas == Some(THIRD_MIGRATION_SCHEMAS.to_string()));
-    ensure!(third_migration_definition.events.is_none());
+    ensure!(
+        third_migration_definition.schemas == Some(THIRD_MIGRATION_SCHEMAS.to_string()),
+        "Third migration: wrong schemas"
+    );
+    ensure!(
+        third_migration_definition.events.is_none(),
+        "Third migration: wrong events"
+    );
 
     // Check data
     let is_table_empty = is_surreal_table_empty(ns_db, "post").await?;
@@ -308,9 +359,18 @@ async fn apply_3_consecutives_schema_and_data_changes_on_clean_db() -> Result<()
         let third_migration_definition_file_path =
             definitions_dir.join(format!("{third_migration_name}.json"));
 
-        ensure!(initial_definition_file_path.exists());
-        ensure!(second_migration_definition_file_path.exists());
-        ensure!(third_migration_definition_file_path.exists());
+        ensure!(
+            initial_definition_file_path.exists(),
+            "Initial definition file should exist"
+        );
+        ensure!(
+            second_migration_definition_file_path.exists(),
+            "Second definition file should exist"
+        );
+        ensure!(
+            third_migration_definition_file_path.exists(),
+            "Third definition file should exist"
+        );
     }
 
     let db_name = generate_random_db_name()?;
@@ -425,9 +485,18 @@ async fn apply_3_consecutives_schema_and_data_changes_on_clean_db() -> Result<()
     let third_migration_definition_file_path =
         definitions_dir.join(format!("{third_migration_name}.json"));
 
-    ensure!(initial_definition_file_path.exists());
-    ensure!(second_migration_definition_file_path.exists());
-    ensure!(third_migration_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Initial definition file should exist"
+    );
+    ensure!(
+        second_migration_definition_file_path.exists(),
+        "Second definition file should exist"
+    );
+    ensure!(
+        third_migration_definition_file_path.exists(),
+        "Third definition file should exist"
+    );
 
     Ok(())
 }
@@ -491,7 +560,7 @@ async fn apply_3_consecutives_schema_and_data_changes_then_down_to_previous_migr
     };
 
     let table_definitions = get_surrealdb_table_definitions(Some(db_configuration)).await?;
-    ensure!(table_definitions.len() == 8);
+    ensure!(table_definitions.len() == 8, "Wrong number of tables");
 
     Ok(())
 }
@@ -554,7 +623,7 @@ async fn apply_3_consecutives_schema_and_data_changes_then_down_to_first_migrati
     };
 
     let table_definitions = get_surrealdb_table_definitions(Some(db_configuration)).await?;
-    ensure!(table_definitions.len() == 7);
+    ensure!(table_definitions.len() == 7, "Wrong number of tables");
 
     Ok(())
 }

--- a/tests/cli/apply/up.rs
+++ b/tests/cli/apply/up.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use color_eyre::eyre::{ensure, Result};
 use assert_fs::TempDir;
 use predicates::prelude::*;
 

--- a/tests/cli/apply/up_to.rs
+++ b/tests/cli/apply/up_to.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 
 use crate::helpers::*;
 

--- a/tests/cli/apply/validate_version_order.rs
+++ b/tests/cli/apply/validate_version_order.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 
 use crate::helpers::*;
 

--- a/tests/cli/branch/diff.rs
+++ b/tests/cli/branch/diff.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 use serial_test::serial;
 
 use crate::helpers::*;

--- a/tests/cli/branch/list.rs
+++ b/tests/cli/branch/list.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use assert_fs::TempDir;
 use cli_table::{format::Border, Cell, ColorChoice, Style, Table};
+use color_eyre::eyre::Result;
 use serial_test::serial;
 
 use crate::helpers::*;

--- a/tests/cli/branch/merge/overwrite.rs
+++ b/tests/cli/branch/merge/overwrite.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use color_eyre::eyre::{ensure, Result};
 use assert_fs::TempDir;
 use serial_test::serial;
 

--- a/tests/cli/branch/new.rs
+++ b/tests/cli/branch/new.rs
@@ -1,5 +1,8 @@
-use anyhow::{anyhow, ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::{
+    eyre::{ensure, eyre},
+    Result,
+};
 use regex::Regex;
 use serial_test::serial;
 
@@ -130,9 +133,9 @@ db: (\S+)\n$",
 
     let branch_name = regex
         .captures(&output)
-        .ok_or_else(|| anyhow!("Output should match regex #1"))?
+        .ok_or_else(|| eyre!("Output should match regex #1"))?
         .get(1)
-        .ok_or_else(|| anyhow!("Output should match regex #2"))?
+        .ok_or_else(|| eyre!("Output should match regex #2"))?
         .as_str();
 
     // Check "branch" record exist in surrealdb

--- a/tests/cli/branch/remove.rs
+++ b/tests/cli/branch/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use color_eyre::eyre::{ensure, Result};
 use assert_fs::TempDir;
 use serial_test::serial;
 

--- a/tests/cli/branch/status.rs
+++ b/tests/cli/branch/status.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::Result;
 use regex::Regex;
 use serial_test::serial;
 

--- a/tests/cli/create/event.rs
+++ b/tests/cli/create/event.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::eyre::{ensure, Result};
 use pretty_assertions::assert_eq;
 
 use crate::helpers::*;
@@ -96,6 +96,7 @@ DEFINE FIELD created_at ON publish_post;
 DEFINE EVENT publish_post ON TABLE publish_post WHEN $event == \"CREATE\" THEN (
     # TODO
 );",
+        "invalid publish post file string"
     );
 
     Ok(())
@@ -130,6 +131,7 @@ DEFINE FIELD created_at ON publish_post;
 DEFINE EVENT publish_post ON TABLE publish_post WHEN $event == \"CREATE\" THEN (
     # TODO
 );",
+        "invalid publish post file string"
     );
 
     Ok(())

--- a/tests/cli/create/migration.rs
+++ b/tests/cli/create/migration.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 use pretty_assertions::assert_eq;
 use std::fs;
 

--- a/tests/cli/create/schema.rs
+++ b/tests/cli/create/schema.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::eyre::{ensure, Result};
 use pretty_assertions::assert_eq;
 
 use crate::helpers::*;
@@ -86,7 +86,8 @@ fn create_schemafull_table_file_from_config() -> Result<()> {
 
 DEFINE FIELD name ON post;
 DEFINE FIELD title ON post;
-DEFINE FIELD published_at ON post;"
+DEFINE FIELD published_at ON post;",
+        "Expected file contents to match"
     );
 
     Ok(())
@@ -117,7 +118,8 @@ fn create_schemaless_table_file_from_invalid_config() -> Result<()> {
 
 DEFINE FIELD name ON post;
 DEFINE FIELD title ON post;
-DEFINE FIELD published_at ON post;"
+DEFINE FIELD published_at ON post;",
+        "Expected file contents to match"
     );
 
     Ok(())

--- a/tests/cli/definitions.rs
+++ b/tests/cli/definitions.rs
@@ -1,5 +1,8 @@
-use anyhow::{ensure, Context, Result};
 use assert_fs::TempDir;
+use color_eyre::{
+    eyre::{ensure, ContextCompat, WrapErr},
+    Result,
+};
 use fs_extra::dir::{DirEntryAttr, DirEntryValue};
 use std::collections::HashSet;
 
@@ -29,17 +32,26 @@ fn initial_definition_on_initial_schema_changes() -> Result<()> {
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 1);
+    ensure!(
+        definitions_files.count() == 1,
+        "Expected only one definition file"
+    );
 
     let initial_definition_file_path = definitions_dir.join("_initial.json");
 
-    ensure!(initial_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Expected _initial.json file to exist"
+    );
 
     let initial_migration_definition_str = std::fs::read_to_string(initial_definition_file_path)?;
     let initial_migration_definition =
         serde_json::from_str::<MigrationDefinition>(&initial_migration_definition_str)?;
 
-    ensure!(initial_migration_definition.schemas == Some(INITIAL_DEFINITION_SCHEMAS.to_string()));
+    ensure!(
+        initial_migration_definition.schemas == Some(INITIAL_DEFINITION_SCHEMAS.to_string()),
+        "Expected initial definition to be equal to the initial definition schema"
+    );
 
     Ok(())
 }
@@ -67,11 +79,17 @@ fn initial_definition_on_initial_migrations() -> Result<()> {
             Ok(entry) => entry.path().is_file(),
             Err(_) => false,
         });
-    ensure!(definitions_files.count() == 1);
+    ensure!(
+        definitions_files.count() == 1,
+        "Expected only one definition file"
+    );
 
     let initial_definition_file_path = definitions_dir.join("_initial.json");
 
-    ensure!(initial_definition_file_path.exists());
+    ensure!(
+        initial_definition_file_path.exists(),
+        "Expected _initial.json file to exist"
+    );
 
     Ok(())
 }
@@ -119,7 +137,10 @@ fn create_new_definition_on_new_migrations() -> Result<()> {
         b.cmp(&a)
     });
 
-    ensure!(definitions_files.len() == 2);
+    ensure!(
+        definitions_files.len() == 2,
+        "Expected two definition files"
+    );
 
     let initial_definition_file = definitions_files
         .first()
@@ -130,7 +151,10 @@ fn create_new_definition_on_new_migrations() -> Result<()> {
         _ => None,
     };
 
-    ensure!(initial_definition_full_name == Some(&"_initial.json".to_string()));
+    ensure!(
+        initial_definition_full_name == Some(&"_initial.json".to_string()),
+        "invalid initial definition file name"
+    );
 
     let new_definition_file = definitions_files
         .last()
@@ -146,7 +170,10 @@ fn create_new_definition_on_new_migrations() -> Result<()> {
         _ => "".to_string(),
     };
 
-    ensure!(!new_definition_file_content.is_empty());
+    ensure!(
+        !new_definition_file_content.is_empty(),
+        "empty new definition file"
+    );
 
     Ok(())
 }

--- a/tests/cli/list.rs
+++ b/tests/cli/list.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use assert_fs::TempDir;
 use chrono::Local;
+use color_eyre::eyre::Result;
 
 use crate::helpers::*;
 

--- a/tests/cli/remove.rs
+++ b/tests/cli/remove.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::Result;
 
 use crate::helpers::*;
 

--- a/tests/cli/scaffold/schema.rs
+++ b/tests/cli/scaffold/schema.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 

--- a/tests/cli/scaffold/template.rs
+++ b/tests/cli/scaffold/template.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::eyre::Result;
 use std::path::Path;
 
 use crate::helpers::*;

--- a/tests/helpers/assert.rs
+++ b/tests/helpers/assert.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use color_eyre::{eyre::eyre, Result};
 use std::path::Path;
 
 pub fn are_folders_equivalent(path_one: &Path, path_two: &Path) -> Result<bool> {
@@ -9,7 +9,7 @@ pub fn are_folders_equivalent(path_one: &Path, path_two: &Path) -> Result<bool> 
             let are_equivalent = !is_different;
             Ok(are_equivalent)
         }
-        Err(error) => Err(anyhow!("Cannot compare folders. {:?}", error)),
+        Err(error) => Err(eyre!("Cannot compare folders. {:?}", error)),
     }
 }
 

--- a/tests/helpers/common.rs
+++ b/tests/helpers/common.rs
@@ -1,5 +1,5 @@
-use anyhow::{anyhow, Context, Result};
 use assert_cmd::Command;
+use color_eyre::eyre::{eyre, ContextCompat, Result};
 use names::{Generator, Name};
 use std::{
     fs, io,
@@ -114,12 +114,15 @@ pub fn get_third_migration_name(path: &Path) -> Result<String> {
     get_nth_migration_name(path, 2)
 }
 
-fn get_nth_migration_name(path: &Path, index: i8) -> std::result::Result<String, anyhow::Error> {
+fn get_nth_migration_name(
+    path: &Path,
+    index: i8,
+) -> std::result::Result<String, color_eyre::eyre::Error> {
     let migration_name = get_nth_migration_file(path, index)?
         .file_stem()
-        .ok_or_else(|| anyhow!("Could not get file stem"))?
+        .ok_or_else(|| eyre!("Could not get file stem"))?
         .to_str()
-        .ok_or_else(|| anyhow!("Could not convert file stem to str"))?
+        .ok_or_else(|| eyre!("Could not convert file stem to str"))?
         .to_owned();
 
     Ok(migration_name)
@@ -140,7 +143,7 @@ fn get_nth_migration_file(path: &Path, index: i8) -> Result<PathBuf> {
 
     let first_migration_file = migration_files
         .get(index as usize)
-        .ok_or_else(|| anyhow!("No migration files found"))?;
+        .ok_or_else(|| eyre!("No migration files found"))?;
 
     Ok(first_migration_file.to_path_buf())
 }

--- a/tests/helpers/io.rs
+++ b/tests/helpers/io.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use color_eyre::eyre::{ContextCompat, Result};
 use std::{fs, path::Path};
 
 use super::create_cmd;

--- a/tests/helpers/surrealdb.rs
+++ b/tests/helpers/surrealdb.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use color_eyre::eyre::{ContextCompat, Result};
 use std::collections::HashMap;
 use surrealdb::{
     engine::any::{connect, Any},

--- a/tests/library/down.rs
+++ b/tests/library/down.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::{eyre::ensure, Result};
 use surrealdb_migrations::MigrationRunner;
 
 use crate::helpers::*;
@@ -29,7 +29,10 @@ async fn apply_revert_all_migrations() -> Result<()> {
     runner.down("0").await?;
 
     let migrations_applied = runner.list().await?;
-    ensure!(migrations_applied.len() == 0);
+    ensure!(
+        migrations_applied.is_empty(),
+        "Expected no migrations to be applied"
+    );
 
     Ok(())
 }
@@ -60,7 +63,10 @@ async fn apply_revert_to_first_migration() -> Result<()> {
     runner.down(&first_migration_name).await?;
 
     let migrations_applied = runner.list().await?;
-    ensure!(migrations_applied.len() == 1);
+    ensure!(
+        migrations_applied.len() == 1,
+        "Expected 1 migration to be applied"
+    );
 
     Ok(())
 }

--- a/tests/library/list.rs
+++ b/tests/library/list.rs
@@ -1,6 +1,9 @@
-use anyhow::{ensure, Context, Result};
 use assert_fs::TempDir;
 use chrono::{DateTime, Local};
+use color_eyre::{
+    eyre::{ensure, Context, ContextCompat},
+    Result,
+};
 use surrealdb_migrations::MigrationRunner;
 
 use crate::helpers::*;
@@ -28,7 +31,10 @@ async fn list_empty_migrations() -> Result<()> {
 
     let migrations_applied = runner.list().await?;
 
-    ensure!(migrations_applied.len() == 0);
+    ensure!(
+        migrations_applied.is_empty(),
+        "Expected no migrations to be applied"
+    );
 
     Ok(())
 }
@@ -58,7 +64,10 @@ async fn list_blog_migrations() -> Result<()> {
 
     let migrations_applied = runner.list().await?;
 
-    ensure!(migrations_applied.len() == 3);
+    ensure!(
+        migrations_applied.len() == 3,
+        "Expected 3 migrations to be applied"
+    );
 
     let date_prefix = now.format("%Y%m%d_%H%M").to_string();
 
@@ -69,34 +78,55 @@ async fn list_blog_migrations() -> Result<()> {
         .get(0)
         .context("Cannot get first migration")?;
 
-    ensure!(first_migration.script_name == format!("{}01_AddAdminUser", date_prefix));
-    ensure!(now_timestamp_range.contains(
-        &DateTime::parse_from_rfc3339(&first_migration.executed_at)
-            .map(|dt| dt.timestamp())
-            .context("Cannot parse first migration execution date")?
-    ));
+    ensure!(
+        first_migration.script_name == format!("{}01_AddAdminUser", date_prefix),
+        "Expected first migration script name to be {}01_AddAdminUser",
+        date_prefix
+    );
+    ensure!(
+        now_timestamp_range.contains(
+            &DateTime::parse_from_rfc3339(&first_migration.executed_at)
+                .map(|dt| dt.timestamp())
+                .context("Cannot parse first migration execution date")?
+        ),
+        "Expected first migration to be executed just now"
+    );
 
     let second_migration = migrations_applied
         .get(1)
         .context("Cannot get second migration")?;
 
-    ensure!(second_migration.script_name == format!("{}02_AddPost", date_prefix));
-    ensure!(now_timestamp_range.contains(
-        &DateTime::parse_from_rfc3339(&second_migration.executed_at)
-            .map(|dt| dt.timestamp())
-            .context("Cannot parse second migration execution date")?
-    ));
+    ensure!(
+        second_migration.script_name == format!("{}02_AddPost", date_prefix),
+        "Expected second migration script name to be {}02_AddPost",
+        date_prefix
+    );
+    ensure!(
+        now_timestamp_range.contains(
+            &DateTime::parse_from_rfc3339(&second_migration.executed_at)
+                .map(|dt| dt.timestamp())
+                .context("Cannot parse second migration execution date")?
+        ),
+        "Expected second migration to be executed just now"
+    );
 
     let third_migration = migrations_applied
         .get(2)
         .context("Cannot get third migration")?;
 
-    ensure!(third_migration.script_name == format!("{}03_CommentPost", date_prefix));
-    ensure!(now_timestamp_range.contains(
-        &DateTime::parse_from_rfc3339(&third_migration.executed_at)
-            .map(|dt| dt.timestamp())
-            .context("Cannot parse third migration execution date")?
-    ));
+    ensure!(
+        third_migration.script_name == format!("{}03_CommentPost", date_prefix),
+        "Expected third migration script name to be {}03_CommentPost",
+        date_prefix
+    );
+    ensure!(
+        now_timestamp_range.contains(
+            &DateTime::parse_from_rfc3339(&third_migration.executed_at)
+                .map(|dt| dt.timestamp())
+                .context("Cannot parse third migration execution date")?
+        ),
+        "Expected third migration to be executed just now"
+    );
 
     Ok(())
 }

--- a/tests/library/load_files.rs
+++ b/tests/library/load_files.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::Result;
 use include_dir::{include_dir, Dir};
 use surrealdb_migrations::MigrationRunner;
 

--- a/tests/library/up.rs
+++ b/tests/library/up.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use assert_fs::TempDir;
+use color_eyre::Result;
 use surrealdb_migrations::MigrationRunner;
 
 use crate::helpers::*;

--- a/tests/library/up_to.rs
+++ b/tests/library/up_to.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::eyre::{ensure, Result};
 use surrealdb_migrations::MigrationRunner;
 
 use crate::helpers::*;
@@ -29,7 +29,10 @@ async fn apply_with_skipped_migrations() -> Result<()> {
     runner.up_to(&first_migration_name).await?;
 
     let migrations_applied = runner.list().await?;
-    ensure!(migrations_applied.len() == 1);
+    ensure!(
+        migrations_applied.len() == 1,
+        "Expected 1 migration to be applied"
+    );
 
     Ok(())
 }

--- a/tests/library/use_config_file.rs
+++ b/tests/library/use_config_file.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use color_eyre::eyre::{ensure, Result};
 use surrealdb_migrations::MigrationRunner;
 
 use crate::helpers::*;

--- a/tests/library/validate_version_order.rs
+++ b/tests/library/validate_version_order.rs
@@ -1,5 +1,5 @@
-use anyhow::{ensure, Result};
 use assert_fs::TempDir;
+use color_eyre::eyre::{ensure, Result};
 use regex::Regex;
 use surrealdb_migrations::MigrationRunner;
 
@@ -117,7 +117,7 @@ async fn fails_if_migrations_applied_with_new_migration_before_last_applied() ->
 
     let result = runner.validate_version_order().await;
 
-    ensure!(result.is_err());
+    ensure!(result.is_err(), "Expected validation to fail");
 
     let error_regex =
         Regex::new(r"The following migrations have not been applied: \d+_\d+_AddAdminUser")?;
@@ -125,7 +125,10 @@ async fn fails_if_migrations_applied_with_new_migration_before_last_applied() ->
     let error_str = result.unwrap_err().to_string();
     let error_str = error_str.as_str();
 
-    ensure!(error_regex.is_match(error_str));
+    ensure!(
+        error_regex.is_match(error_str),
+        "Expected validation to fail"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

I was experiencing some issues using the CLI (my fault). The error messages were produced unhelpful (such as `Error: No such file or directory (os error 2)`, and I didn't know where the error was originating from.

## Solution

To resolve this, I replaced `anyhow` with `color_eyre` as it improves upon anyhow in multiple ways. It not only improves the aesthetics of the error messages, but provides a much more useful stack trace, which pointed me to the issue in `io.rs`, so I improved the feedback of the error in `io.rs`, and this helped me identify the issue I was having.

Additionally, I added context messages to all `ensure!` macro calls in the integration tests to provide more context in the case of failures.