### PR TITLE
Build docker image for multiple processor architectures

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -10,13 +10,15 @@ env:
 
 jobs:
   docker-build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-latest
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Prepare
         run: |
@@ -28,10 +30,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGE_NAME }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        if: matrix.platform != 'linux/amd64'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,104 @@
+name: Build and Deploy
+
+on:
+  release:
+    types: [created]
+
+env:
+  IMAGE_NAME: dbottiau/surrealdb-migrations
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.platform != 'linux/amd64'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -9,7 +9,7 @@ env:
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 jobs:
-  build:
+  docker-build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,10 +66,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  docker-merge:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - docker-build
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [created]
 
-env:
-  IMAGE_NAME: dbottiau/surrealdb-migrations
-  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-
 jobs:
   release-binary:
     name: release ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [created]
 
+env:
+  IMAGE_NAME: surrealdb-migrations
+  REGISTRY: ghcr.io
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+
 jobs:
   release-binary:
     name: release ${{ matrix.target }}
@@ -62,6 +67,57 @@ jobs:
         with:
           files: target/release/surrealdb-migrations.exe
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  release-docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: matrix.platform != 'linux/amd64'
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=edge,branch=main
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ matrix.platform }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.api
+          platforms: ${{ matrix.platform }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   publish:
     needs: [release-binary, release-exe]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     types: [created]
 
 env:
-  IMAGE_NAME: surrealdb-migrations
-  REGISTRY: ghcr.io
+  IMAGE_NAME: dbottiau/surrealdb-migrations
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 jobs:
@@ -67,57 +66,6 @@ jobs:
         with:
           files: target/release/surrealdb-migrations.exe
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  release-docker:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64/v8
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        if: matrix.platform != 'linux/amd64'
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=edge,branch=main
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.platform }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Login to GitHub Docker Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: docker/Dockerfile.api
-          platforms: ${{ matrix.platform }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
   publish:
     needs: [release-binary, release-exe]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM --platform=$BUILDPLATFORM rust:1.82 AS builder
+FROM rust:1.82 AS builder
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
 RUN apt-get update && apt-get install -y musl-tools
+
+WORKDIR /volume
+ADD src src
+ADD templates templates
+ADD Cargo.toml Cargo.toml
+ADD Cargo.lock Cargo.lock
 
 RUN case "$TARGETPLATFORM" in \
     "linux/amd64")                   echo "x86_64-unknown-linux-musl" > /tmp/target ;; \
@@ -11,17 +17,11 @@ RUN case "$TARGETPLATFORM" in \
     esac
 
 RUN rustup target add $(cat /tmp/target)
-
-WORKDIR /volume
-ADD src src
-ADD templates templates
-ADD Cargo.toml Cargo.toml
-ADD Cargo.lock Cargo.lock
 RUN cargo build --release --target $(cat /tmp/target)
 
 RUN mkdir -p /tmp/bin && cp /volume/target/$(cat /tmp/target)/release/surrealdb-migrations /tmp/bin/
 
-FROM --platform=$TARGETPLATFORM alpine
+FROM alpine
 COPY --from=builder /tmp/bin/surrealdb-migrations ./surrealdb-migrations
 RUN chmod o+rx ./surrealdb-migrations
 ENTRYPOINT [ "/surrealdb-migrations" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,27 @@
-FROM clux/muslrust:1.80.1-stable as builder
+FROM --platform=$BUILDPLATFORM rust:1.82 AS builder
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+RUN apt-get update && apt-get install -y musl-tools
+
+RUN case "$TARGETPLATFORM" in \
+    "linux/amd64")                   echo "x86_64-unknown-linux-musl" > /tmp/target ;; \
+    "linux/arm64"|"linux/arm64/v8")  echo "aarch64-unknown-linux-musl" > /tmp/target ;; \
+    *)                               echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ;; \
+    esac
+
+RUN rustup target add $(cat /tmp/target)
+
 WORKDIR /volume
 ADD src src
 ADD templates templates
 ADD Cargo.toml Cargo.toml
 ADD Cargo.lock Cargo.lock
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release --target $(cat /tmp/target)
 
-FROM alpine
-COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/surrealdb-migrations ./surrealdb-migrations
+RUN mkdir -p /tmp/bin && cp /volume/target/$(cat /tmp/target)/release/surrealdb-migrations /tmp/bin/
+
+FROM --platform=$TARGETPLATFORM alpine
+COPY --from=builder /tmp/bin/surrealdb-migrations ./surrealdb-migrations
 RUN chmod o+rx ./surrealdb-migrations
 ENTRYPOINT [ "/surrealdb-migrations" ]


### PR DESCRIPTION
This is a proof of concept PR. It currently pushes to the GitHub docker registry. Maybe you can activate the pipeline to see if it works. Later you can then change it to push to docker hub.

I droped the [muslrust](https://github.com/clux/muslrust) image in favour of the rust image. This is also noted in the readme: https://github.com/clux/muslrust?tab=readme-ov-file#alternatives

> [official rust image](https://hub.docker.com/_/rust) can target add and easily cross-build when not needing [C libraries](https://github.com/clux/muslrust?tab=readme-ov-file#c-libraries)

I don't think that you need C libs which muslrust provides.