### PR TITLE
perf: Only validate schema when there are migrations

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -443,7 +443,7 @@ async fn apply_migrations<C: Connection>(
             }
         }?;
 
-        if !has_migration_files_to_execute {
+        if has_migration_files_to_execute {
             let schemas_statements = current_definition.schemas.to_string();
             let events_statements = current_definition.events.to_string();
 


### PR DESCRIPTION
This change corrects an upstream commit (2eae815897fa5f9001a6b22009309304ca0e33f9) which attempts to address the underlying issue but instead only renames the variable as suggested rather than resolves the logic https://github.com/Odonno/surrealdb-migrations/commit/2eae815897fa5f9001a6b22009309304ca0e33f9#diff-0733c7dea2696bb358f05483810e0a2ac911a04f2f440501c4a6660fb42cd63fR430-R446

The issue is that this piece of code gates schema validation, which is a very expensive process. On a test database of mine about 100MiB/75k entries in size, hosted in a system with a 7950X3D & a P5800X it takes about a _minute_ to complete.

Resolves #103